### PR TITLE
fix bug can not access editor command

### DIFF
--- a/Nodify/Compatibility/Commands/CanExecuteRoutedEventArgs.cs
+++ b/Nodify/Compatibility/Commands/CanExecuteRoutedEventArgs.cs
@@ -1,6 +1,6 @@
 namespace Nodify.Compatibility;
 
-internal sealed class CanExecuteRoutedEventArgs : RoutedEventArgs
+public sealed class CanExecuteRoutedEventArgs : RoutedEventArgs
 {
     public ICommand Command { get; }
 
@@ -8,7 +8,7 @@ internal sealed class CanExecuteRoutedEventArgs : RoutedEventArgs
 
     public bool CanExecute { get; set; }
 
-    internal CanExecuteRoutedEventArgs(ICommand command, object? parameter)
+    public CanExecuteRoutedEventArgs(ICommand command, object? parameter)
     {
         Command = command ?? throw new ArgumentNullException(nameof(command));
         Parameter = parameter;

--- a/Nodify/Compatibility/Commands/ExecutedRoutedEventArgs.cs
+++ b/Nodify/Compatibility/Commands/ExecutedRoutedEventArgs.cs
@@ -1,6 +1,6 @@
 namespace Nodify.Compatibility;
 
-internal sealed class ExecutedRoutedEventArgs : RoutedEventArgs
+public sealed class ExecutedRoutedEventArgs : RoutedEventArgs
 {
     public ICommand Command { get; }
 

--- a/Nodify/Compatibility/Commands/RoutedCommand.cs
+++ b/Nodify/Compatibility/Commands/RoutedCommand.cs
@@ -1,14 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Input;
-using Avalonia.Input;
-using Avalonia.Interactivity;
-
 namespace Nodify.Compatibility;
 
 // Ported from https://github.com/AvaloniaUI/AvaloniaEdit/blob/master/src/AvaloniaEdit/RoutedCommand.cs
-internal class RoutedCommand : ICommand
+public class RoutedCommand : ICommand
 {
     private static IInputElement? _focusedElement;
 

--- a/Nodify/Compatibility/Commands/RoutedUICommand.cs
+++ b/Nodify/Compatibility/Commands/RoutedUICommand.cs
@@ -1,6 +1,6 @@
 namespace Nodify.Compatibility;
 
-internal class RoutedUICommand : RoutedCommand
+public class RoutedUICommand : RoutedCommand
 {
     public string Text { get; }
     

--- a/Nodify/Compatibility/Input/InputGestureCollection.cs
+++ b/Nodify/Compatibility/Input/InputGestureCollection.cs
@@ -1,8 +1,6 @@
-using Avalonia.Collections;
-
 namespace Nodify.Compatibility;
 
-internal class InputGestureCollection : AvaloniaList<InputGesture>
+public class InputGestureCollection : AvaloniaList<InputGesture>
 {
         
 }

--- a/Nodify/EditorCommands.cs
+++ b/Nodify/EditorCommands.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls.Primitives;
-using System.Windows.Input;
-
+﻿
 namespace Nodify
 {
-    internal static class EditorCommands
+    public static class EditorCommands
     {
         /// <summary>
         /// Specifies the possible alignment values used by the <see cref="Align"/> command.
@@ -181,9 +174,11 @@ namespace Nodify
                     case Point location:
                         editor.BringIntoView(location);
                         break;
+
                     case string str:
                         editor.BringIntoView(Point.Parse(str));
                         break;
+
                     default:
                         editor.BringIntoView(new Point());
                         break;

--- a/Nodify/EditorCommands.cs
+++ b/Nodify/EditorCommands.cs
@@ -1,4 +1,11 @@
-﻿
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
 namespace Nodify
 {
     public static class EditorCommands
@@ -174,11 +181,9 @@ namespace Nodify
                     case Point location:
                         editor.BringIntoView(location);
                         break;
-
                     case string str:
                         editor.BringIntoView(Point.Parse(str));
                         break;
-
                     default:
                         editor.BringIntoView(new Point());
                         break;


### PR DESCRIPTION
### 📝 Description of the Change

I modified the access modifier of `EditorCommand`. which can not be accessed if used in different assemblies.

What is this pull request about?

https://github.com/BAndysc/nodify-avalonia/issues/15

### 🐛 Possible Drawbacks

Are there any possible side-effects or negative impacts with this code change?
No
