### PR TITLE
Fix Calculator context menu and converter issues.

### DIFF
--- a/Examples/Nodify.Calculator/EditorView.xaml.cs
+++ b/Examples/Nodify.Calculator/EditorView.xaml.cs
@@ -10,7 +10,7 @@ namespace Nodify.Calculator
         {
             InitializeComponent();
 
-            PointerPressedEvent.AddClassHandler<NodifyEditor>(CloseOperationsMenuPointerPressed, RoutingStrategies.Tunnel);
+            PointerPressedEvent.AddClassHandler<NodifyEditor>(CloseOperationsMenuPointerPressed);
             ItemContainer.DragStartedEvent.AddClassHandler<ItemContainer>(CloseOperationsMenu);
             PointerReleasedEvent.AddClassHandler<NodifyEditor>(OpenOperationsMenu);
             Editor.AddHandler(DragDrop.DropEvent, OnDropNode);

--- a/Examples/Nodify.Calculator/Nodify.Calculator.csproj
+++ b/Examples/Nodify.Calculator/Nodify.Calculator.csproj
@@ -17,13 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Playground/Nodify.Playground.csproj
+++ b/Examples/Nodify.Playground/Nodify.Playground.csproj
@@ -14,13 +14,13 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
+++ b/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
@@ -20,13 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
+++ b/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="11.1.0"/>
+    <PackageReference Include="Avalonia.Browser" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shapes/Nodify.Shapes.csproj
+++ b/Examples/Nodify.Shapes/Nodify.Shapes.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shared/Nodify.Shared.csproj
+++ b/Examples/Nodify.Shared/Nodify.Shared.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
+++ b/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0"/>
+    <PackageReference Include="Avalonia" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4"/>
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Nodify/Helpers/UnscaleTransformConverter.cs
+++ b/Nodify/Helpers/UnscaleTransformConverter.cs
@@ -40,7 +40,9 @@ namespace Nodify
     {
         public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
-            Point result = (Point)((Vector)(Point)values[0] * (double)values[1]);
+            if (values.Any(x => x is UnsetValueType)) return false;
+
+            Point result = (Point)((Vector)(Point)values[0]! * (double)values[1]!);
             return result;
         }
 

--- a/Nodify/Minimap/SubtractConverter.cs
+++ b/Nodify/Minimap/SubtractConverter.cs
@@ -8,7 +8,9 @@ namespace Nodify
     {
         public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
-            double result = (double)values[0] - (double)values[1];
+            if (values.Any(x => x is UnsetValueType)) return false;
+
+            double result = (double)values[0]! - (double)values[1]!;
             return result;
         }
 

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -48,7 +48,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0" />
+    <PackageReference Include="Avalonia" Version="11.1.4" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Themes\*.xaml" />


### PR DESCRIPTION
### 📝 Description of the Change

Fixes for Calculator example context menu and associated converters.  Previously, the context menu was being closed prematurely, preventing fired events from completing as intended.

### 🐛 Possible Drawbacks

None.
