### PR TITLE
fix: make FitToScreenExtentMargin work correctly

### DIFF
--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1088,7 +1088,7 @@ namespace Nodify
         public void FitToScreen(Rect? area = null)
         {
             Rect extent = area ?? ItemsExtent;
-            extent.Inflate(FitToScreenExtentMargin);
+            extent = extent.Inflate(FitToScreenExtentMargin);
 
             if (extent.Width > 0 && extent.Height > 0)
             {


### PR DESCRIPTION
### 📝 Description of the Change

Fixed the `extent` calculation logic that caused incorrect viewport fitting. 

### 🐛 Possible Drawbacks

None.

Closed #35 
