### PR TITLE
fix: Prevent adding null to selected items

### DIFF
--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1437,7 +1437,7 @@ namespace Nodify
                 for (var i = 0; i < added.Count; i++)
                 {
                     // Ensure no duplicates are added
-                    if (!selected.Contains(added[i]))
+                    if (added[i] is not null && !selected.Contains(added[i]))
                     {
                         selected.Add(added[i]);
                     }


### PR DESCRIPTION
When running the shape demo, clicking a shape causes an error.
I'm not sure if it's caused by the differences between Avalonia and WPF, but OnSelectionChanged is triggered once by default when the application starts.