### PR TITLE
fix : Resolve issue where the minimap does not refresh node positions…

### DIFF
--- a/Nodify/Compatibility/PanelUtilities.cs
+++ b/Nodify/Compatibility/PanelUtilities.cs
@@ -1,9 +1,3 @@
-using System;
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Layout;
-using Avalonia.VisualTree;
-
 namespace Nodify.Compatibility
 {
     internal static class PanelUtilities
@@ -15,7 +9,7 @@ namespace Nodify.Compatibility
             var panel = control?.GetVisualParent() as TPanel;
             panel?.InvalidateArrange();
         }
-        
+
         public static void AffectsParentArrange<TPanel>(params AvaloniaProperty[] properties)
             where TPanel : Layoutable
         {
@@ -24,7 +18,25 @@ namespace Nodify.Compatibility
                 property.Changed.Subscribe(new AnonuymousObserver<AvaloniaPropertyChangedEventArgs>(AffectsParentArrangeInvalidate<TPanel>));
             }
         }
-        
+
+
+        private static void AffectsParentMeasureInvalidate<TPanel>(AvaloniaPropertyChangedEventArgs e)
+            where TPanel : Layoutable
+        {
+            var control = e.Sender as Control;
+            var panel = control?.GetVisualParent() as TPanel;
+            panel?.InvalidateMeasure();
+        }
+
+        public static void AffectsParentMeasure<TPanel>(params AvaloniaProperty[] properties)
+            where TPanel : Layoutable
+        {
+            foreach (var property in properties)
+            {
+                property.Changed.Subscribe(new AnonuymousObserver<AvaloniaPropertyChangedEventArgs>(AffectsParentMeasureInvalidate<TPanel>));
+            }
+        }
+
         private class AnonuymousObserver<T> : IObserver<T>
         {
             private readonly Action<T> _onNext;

--- a/Nodify/Minimap/MinimapItem.cs
+++ b/Nodify/Minimap/MinimapItem.cs
@@ -18,7 +18,7 @@ namespace Nodify
 
         static MinimapItem()
         {
-            PanelUtilities.AffectsParentArrange<DecoratorContainer>(LocationProperty);
+            PanelUtilities.AffectsParentMeasure<Layoutable>(LocationProperty);
         }
     }
 }


### PR DESCRIPTION
When using the playground project, I discovered that the minimap fails to update node positions and boundaries in real-time when nodes are moved. This PR fixes that issue.