### PR TITLE
fix: Avalonia 12 and .NET 10 Upgrade #43

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AvaloniaVersion>11.1.0</AvaloniaVersion>
+    <AvaloniaVersion>12.0.2</AvaloniaVersion>
+    <XamlBehaviorsVersion>12.0.0</XamlBehaviorsVersion>
+    <ProDiagnosticsVersion>12.0.0</ProDiagnosticsVersion>
   </PropertyGroup>
 </Project>

--- a/Examples/Nodify.Calculator/EditorView.xaml.cs
+++ b/Examples/Nodify.Calculator/EditorView.xaml.cs
@@ -1,11 +1,15 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Avalonia.Input;
 
 namespace Nodify.Calculator
 {
     public partial class EditorView : UserControl
     {
+        private static readonly DataFormat<OperationInfoViewModel> OperationDragFormat =
+            DataFormat.CreateInProcessFormat<OperationInfoViewModel>("nodify.calculator.operation");
+
         public EditorView()
         {
             InitializeComponent();
@@ -47,7 +51,7 @@ namespace Nodify.Calculator
         {
             NodifyEditor? editor = (e.Source as NodifyEditor) ?? (e.Source as Control)?.GetLogicalParent() as NodifyEditor;
             if(editor != null && editor.DataContext is CalculatorViewModel calculator
-                && e.Data.Get(typeof(OperationInfoViewModel).FullName) is OperationInfoViewModel operation)
+                && e.DataTransfer?.TryGetValue(OperationDragFormat) is OperationInfoViewModel operation)
             {
                 OperationViewModel op = OperationFactory.GetOperation(operation);
                 op.Location = editor.GetLocationInsideEditor(e);
@@ -56,28 +60,29 @@ namespace Nodify.Calculator
                 e.Handled = true;
             }
         }
-        
-        private void OnNodeDrag(object? sender, MouseEventArgs e)
+
+        private void OnNodeDrag(object? sender, PointerEventArgs e)
         {
-            if(leftButtonPressed && ((Control)sender).DataContext is OperationInfoViewModel operation)
+            if(_pressedEventArgs is { } pressed && ((Control)sender!).DataContext is OperationInfoViewModel operation)
             {
-                var data = new DataObject();
-                data.Set(typeof(OperationInfoViewModel).FullName, operation);
-                DragDrop.DoDragDrop(e, data, DragDropEffects.Copy);
+                var data = new DataTransfer();
+                data.Add(DataTransferItem.Create(OperationDragFormat, operation));
+                _pressedEventArgs = null;
+                _ = DragDrop.DoDragDropAsync(pressed, data, DragDropEffects.Copy);
             }
         }
 
         private void OnNodePressed(object? sender, PointerPressedEventArgs e)
         {
-            leftButtonPressed = e.GetCurrentPoint(this).Properties.PointerUpdateKind ==
-                                PointerUpdateKind.LeftButtonPressed;
+            _pressedEventArgs = e.GetCurrentPoint(this).Properties.PointerUpdateKind ==
+                                PointerUpdateKind.LeftButtonPressed ? e : null;
         }
 
         private void OnNodeExited(object? sender, PointerEventArgs e)
         {
-            leftButtonPressed = false;
+            _pressedEventArgs = null;
         }
-        
-        private bool leftButtonPressed;
+
+        private PointerPressedEventArgs? _pressedEventArgs;
     }
 }

--- a/Examples/Nodify.Calculator/Nodify.Calculator.csproj
+++ b/Examples/Nodify.Calculator/Nodify.Calculator.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -21,9 +22,9 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
+    <!--Condition below is needed to remove ProDiagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(ProDiagnosticsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Playground"
              xmlns:nodify="https://miroiu.github.io/nodify"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
+             xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
              mc:Ignorable="d"
              Background="{DynamicResource NodifyEditor.BackgroundBrush}"
              d:DesignHeight="450"
@@ -70,39 +71,39 @@
             <Setter Property="(Interaction.Behaviors)">
                 <BehaviorCollectionTemplate>
                     <BehaviorCollection>
-                        <DataTrigger Property="Input.Shape" 
+                        <behaviours:DataTrigger Property="Input.Shape" 
                                      Value="{x:Static local:ConnectorShape.Square}">
-                            <PropertySetter Property="Stroke"
+                            <behaviours:PropertySetter Property="Stroke"
                                     Value="{StaticResource SquareConnectorColor}" />
-                            <PropertySetter Property="Fill"
+                            <behaviours:PropertySetter Property="Fill"
                                     Value="{StaticResource SquareConnectorColor}" />
-                        </DataTrigger>
-                        <DataTrigger Property="Input.Shape" 
+                        </behaviours:DataTrigger>
+                        <behaviours:DataTrigger Property="Input.Shape" 
                                      Value="{x:Static local:ConnectorShape.Triangle}">
-                            <PropertySetter Property="Stroke"
+                            <behaviours:PropertySetter Property="Stroke"
                                     Value="{StaticResource TriangleConnectorColor}" />
-                            <PropertySetter Property="Fill"
+                            <behaviours:PropertySetter Property="Fill"
                                     Value="{StaticResource TriangleConnectorColor}" />
-                        </DataTrigger>
-                        <DataTrigger Property="IsPointerOver" Value="True">
-                            <!-- <DataTrigger.EnterActions> -->
+                        </behaviours:DataTrigger>
+                        <behaviours:DataTrigger Property="IsPointerOver" Value="True">
+                            <!-- <behaviours:DataTrigger.EnterActions> -->
                             <!--     <BeginStoryboard Name="HighlightConnection" Storyboard="{StaticResource HighlightConnection}" /> -->
-                            <!-- </DataTrigger.EnterActions> -->
-                            <!-- <DataTrigger.ExitActions> -->
+                            <!-- </behaviours:DataTrigger.EnterActions> -->
+                            <!-- <behaviours:DataTrigger.ExitActions> -->
                             <!--     <RemoveStoryboard BeginStoryboardName="HighlightConnection" /> -->
-                            <!-- </DataTrigger.ExitActions> -->
-                            <PropertySetter Property="Opacity"
+                            <!-- </behaviours:DataTrigger.ExitActions> -->
+                            <behaviours:PropertySetter Property="Opacity"
                                     Value="1" />
-                        </DataTrigger>
-                        <DataTrigger Property="IsPointerOver" Value="False">
-                            <PropertySetter Property="OutlineBrush"
+                        </behaviours:DataTrigger>
+                        <behaviours:DataTrigger Property="IsPointerOver" Value="False">
+                            <behaviours:PropertySetter Property="OutlineBrush"
                                             Value="Transparent" />
-                        </DataTrigger>
-                        <DataTrigger Property="IsSelectable"
+                        </behaviours:DataTrigger>
+                        <behaviours:DataTrigger Property="IsSelectable"
                                  Value="True">
-                            <PropertySetter Property="Cursor"
+                            <behaviours:PropertySetter Property="Cursor"
                                     Value="Hand" />
-                        </DataTrigger>
+                        </behaviours:DataTrigger>
                     </BehaviorCollection>
                 </BehaviorCollectionTemplate>
             </Setter>
@@ -301,26 +302,26 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="ShowGridLines" Source="{x:Static local:PlaygroundSettings.Instance}"
+                                <behaviours:DataTrigger Property="ShowGridLines" Source="{x:Static local:PlaygroundSettings.Instance}"
                                              Value="True">
-                                    <PropertySetter Property="Background"
+                                    <behaviours:PropertySetter Property="Background"
                                             Value="{StaticResource SmallGridLinesDrawingBrush}" />
-                                </DataTrigger>
-                                <DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
+                                </behaviours:DataTrigger>
+                                <behaviours:DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
                                                      Value="Line">
-                                    <PropertySetter Property="ConnectionTemplate"
+                                    <behaviours:PropertySetter Property="ConnectionTemplate"
                                                     Value="{StaticResource LineConnectionTemplate}" />
-                                </DataTrigger>
-                                <DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
+                                </behaviours:DataTrigger>
+                                <behaviours:DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
                                                      Value="Circuit">
-                                    <PropertySetter Property="ConnectionTemplate"
+                                    <behaviours:PropertySetter Property="ConnectionTemplate"
                                                     Value="{StaticResource CircuitConnectionTemplate}" />
-                                </DataTrigger>
-                                <DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
+                                </behaviours:DataTrigger>
+                                <behaviours:DataTrigger Property="ConnectionStyle" Source="{x:Static local:EditorSettings.Instance}"
                                                      Value="Step">
-                                    <PropertySetter Property="ConnectionTemplate"
+                                    <behaviours:PropertySetter Property="ConnectionTemplate"
                                                     Value="{StaticResource StepConnectionTemplate}" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -384,20 +385,20 @@
                                                 <Setter Property="(Interaction.Behaviors)">
                                                     <BehaviorCollectionTemplate>
                                                         <BehaviorCollection>
-                                                            <DataTrigger Property="Source.Shape" 
+                                                            <behaviours:DataTrigger Property="Source.Shape" 
                                                                          Value="{x:Static local:ConnectorShape.Square}">
-                                                                <PropertySetter Property="Stroke" 
+                                                                <behaviours:PropertySetter Property="Stroke" 
                                                                                 Value="{StaticResource SquareConnectorColor}"/>
-                                                                <PropertySetter Property="Fill" 
+                                                                <behaviours:PropertySetter Property="Fill" 
                                                                                 Value="{StaticResource SquareConnectorColor}"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Property="Source.Shape" 
+                                                            </behaviours:DataTrigger>
+                                                            <behaviours:DataTrigger Property="Source.Shape" 
                                                                          Value="{x:Static local:ConnectorShape.Triangle}">
-                                                                <PropertySetter Property="Stroke" 
+                                                                <behaviours:PropertySetter Property="Stroke" 
                                                                                 Value="{StaticResource TriangleConnectorColor}"/>
-                                                                <PropertySetter Property="Fill" 
+                                                                <behaviours:PropertySetter Property="Fill" 
                                                                                 Value="{StaticResource TriangleConnectorColor}"/>
-                                                            </DataTrigger>
+                                                            </behaviours:DataTrigger>
                                                         </BehaviorCollection>
                                                     </BehaviorCollectionTemplate>
                                                 </Setter>
@@ -434,14 +435,14 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="Shape" 
+                                <behaviours:DataTrigger Property="Shape" 
                                              Value="{x:Static local:ConnectorShape.Square}">
-                                    <PropertySetter Property="ConnectorTemplate" 
+                                    <behaviours:PropertySetter Property="ConnectorTemplate" 
                                                     Value="{StaticResource SquareConnector}" />
-                                    <PropertySetter Property="BorderBrush" 
+                                    <behaviours:PropertySetter Property="BorderBrush" 
                                                     Value="{StaticResource SquareConnectorColor}"/>
-                                    <PropertySetter Property="HeaderTemplate">
-                                        <PropertySetter.Value>
+                                    <behaviours:PropertySetter Property="HeaderTemplate">
+                                        <behaviours:PropertySetter.Value>
                                             <DataTemplate DataType="{x:Type local:ConnectorViewModel}">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Title}" 
@@ -450,17 +451,17 @@
                                                              MinWidth="30" />
                                                 </StackPanel>
                                             </DataTemplate>
-                                        </PropertySetter.Value>
-                                    </PropertySetter>
-                                </DataTrigger>
-                                <DataTrigger Property="Shape" 
+                                        </behaviours:PropertySetter.Value>
+                                    </behaviours:PropertySetter>
+                                </behaviours:DataTrigger>
+                                <behaviours:DataTrigger Property="Shape" 
                                              Value="{x:Static local:ConnectorShape.Triangle}">
-                                    <PropertySetter Property="ConnectorTemplate" 
+                                    <behaviours:PropertySetter Property="ConnectorTemplate" 
                                                     Value="{StaticResource TriangleConnector}" />
-                                    <PropertySetter Property="BorderBrush" 
+                                    <behaviours:PropertySetter Property="BorderBrush" 
                                                     Value="{StaticResource TriangleConnectorColor}"/>
-                                    <PropertySetter Property="HeaderTemplate">
-                                        <PropertySetter.Value>
+                                    <behaviours:PropertySetter Property="HeaderTemplate">
+                                        <behaviours:PropertySetter.Value>
                                             <DataTemplate DataType="{x:Type local:ConnectorViewModel}">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="{Binding Title}" 
@@ -469,9 +470,9 @@
                                                     <CheckBox />
                                                 </StackPanel>
                                             </DataTemplate>
-                                        </PropertySetter.Value>
-                                    </PropertySetter>
-                                </DataTrigger>
+                                        </behaviours:PropertySetter.Value>
+                                    </behaviours:PropertySetter>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -497,20 +498,20 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="Shape" 
+                                <behaviours:DataTrigger Property="Shape" 
                                              Value="{x:Static local:ConnectorShape.Square}">
-                                    <PropertySetter Property="ConnectorTemplate" 
+                                    <behaviours:PropertySetter Property="ConnectorTemplate" 
                                                     Value="{StaticResource SquareConnector}" />
-                                    <PropertySetter Property="BorderBrush" 
+                                    <behaviours:PropertySetter Property="BorderBrush" 
                                                     Value="{StaticResource SquareConnectorColor}"/>
-                                </DataTrigger>
-                                <DataTrigger Property="Shape" 
+                                </behaviours:DataTrigger>
+                                <behaviours:DataTrigger Property="Shape" 
                                              Value="{x:Static local:ConnectorShape.Triangle}">
-                                    <PropertySetter Property="ConnectorTemplate" 
+                                    <behaviours:PropertySetter Property="ConnectorTemplate" 
                                                     Value="{StaticResource TriangleConnector}" />
-                                    <PropertySetter Property="BorderBrush" 
+                                    <behaviours:PropertySetter Property="BorderBrush" 
                                                     Value="{StaticResource TriangleConnectorColor}"/>
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -611,11 +612,11 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="IsSelected" 
+                                <behaviours:DataTrigger Property="IsSelected" 
                                              Value="True">
-                                    <PropertySetter Property="Panel.ZIndex" 
+                                    <behaviours:PropertySetter Property="Panel.ZIndex" 
                                                     Value="1" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>

--- a/Examples/Nodify.Playground/Editor/WpfComboBox.cs
+++ b/Examples/Nodify.Playground/Editor/WpfComboBox.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using Avalonia;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.VisualTree;
@@ -28,7 +30,7 @@ public class WpfComboBox : ComboBox
     
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
-        if ((e.Source as Control)?.GetVisualRoot() is not PopupRoot)
+        if ((e.Source as Visual)?.GetSelfAndVisualAncestors().LastOrDefault() is not PopupRoot)
             e.Handled = true;
         base.OnPointerReleased(e);
     }

--- a/Examples/Nodify.Playground/EditorSettingsView.xaml
+++ b/Examples/Nodify.Playground/EditorSettingsView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Nodify.Playground"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
+             xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
              d:Foreground="{DynamicResource ForegroundBrush}"
              d:Background="{DynamicResource PanelBackgroundBrush}"
              mc:Ignorable="d">
@@ -29,12 +30,12 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="IsExpanded"
+                                <behaviours:DataTrigger Property="IsExpanded"
                                              UseDataContext="False"
                                              Value="True">
-                                    <PropertySetter Property="Tag"
+                                    <behaviours:PropertySetter Property="Tag"
                                                     Value="{StaticResource ExpandDownIcon}" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>

--- a/Examples/Nodify.Playground/MainWindow.xaml
+++ b/Examples/Nodify.Playground/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Nodify.Playground"
         xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
+        xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
         xmlns:nodify="https://miroiu.github.io/nodify"
         mc:Ignorable="d"
         Title="MainWindow"
@@ -61,7 +62,7 @@
                             Content="BRING INTO VIEW"
                             ToolTip.Tip="Bring a random node into view."
                             Theme="{StaticResource HollowButton}" />
-                    <WpfBtn Command="{x:Static nodify:EditorCommands.FitToScreen}"
+                    <behaviours:WpfBtn Command="{x:Static nodify:EditorCommands.FitToScreen}"
                             Content="FIT TO SCREEN"
                             CommandTarget="{Binding EditorInstance, ElementName=EditorView}"
                             ToolTip.Tip="Scales the viewport to fit all nodes if that's possible."
@@ -101,12 +102,12 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="IsExpanded" 
+                                <behaviours:DataTrigger Property="IsExpanded" 
                                              UseDataContext="False"
                                              Value="True">
-                                    <PropertySetter Property="Tag"
+                                    <behaviours:PropertySetter Property="Tag"
                                             Value="{StaticResource ExpandLeftIcon}" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -144,12 +145,12 @@
                                     <Setter Property="(Interaction.Behaviors)">
                                         <BehaviorCollectionTemplate>
                                             <BehaviorCollection>
-                                                <DataTrigger Property="IsExpanded"
+                                                <behaviours:DataTrigger Property="IsExpanded"
                                                              UseDataContext="False"
                                                          Value="True">
-                                                    <PropertySetter Property="Tag"
+                                                    <behaviours:PropertySetter Property="Tag"
                                                             Value="{StaticResource ExpandDownIcon}" />
-                                                </DataTrigger>
+                                                </behaviours:DataTrigger>
                                             </BehaviorCollection>
                                         </BehaviorCollectionTemplate>
                                     </Setter>
@@ -176,12 +177,12 @@
                                     <Setter Property="(Interaction.Behaviors)">
                                         <BehaviorCollectionTemplate>
                                             <BehaviorCollection>
-                                                <DataTrigger Property="IsExpanded"
+                                                <behaviours:DataTrigger Property="IsExpanded"
                                                              UseDataContext="False"
                                                          Value="True">
-                                                    <PropertySetter Property="Tag"
+                                                    <behaviours:PropertySetter Property="Tag"
                                                             Value="{StaticResource ExpandDownIcon}" />
-                                                </DataTrigger>
+                                                </behaviours:DataTrigger>
                                             </BehaviorCollection>
                                         </BehaviorCollectionTemplate>
                                     </Setter>

--- a/Examples/Nodify.Playground/Nodify.Playground.csproj
+++ b/Examples/Nodify.Playground/Nodify.Playground.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -12,15 +13,15 @@
     <ProjectReference Include="..\..\Nodify\Nodify.csproj" />
     <ProjectReference Include="..\Nodify.Shared\Nodify.Shared.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
+    <!--Condition below is needed to remove ProDiagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(ProDiagnosticsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Playground/SettingsView.xaml
+++ b/Examples/Nodify.Playground/SettingsView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Nodify.Playground"
+             xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
              xmlns:nodify="clr-namespace:Nodify;assembly=Nodify.Shared"
              d:DataContext="{d:DesignInstance Type=local:PlaygroundViewModel, IsDesignTimeCreatable=True}"
              d:Foreground="{DynamicResource ForegroundBrush}"
@@ -45,26 +46,26 @@
                                 <Setter Property="(Interaction.Behaviors)">
                                     <BehaviorCollectionTemplate>
                                         <BehaviorCollection>
-                                            <DataTrigger Property="Type" Value="Boolean">
-                                                <PropertySetter Property="ContentTemplate"
+                                            <behaviours:DataTrigger Property="Type" Value="Boolean">
+                                                <behaviours:PropertySetter Property="ContentTemplate"
                                                         Value="{StaticResource ResourceKey=BooleanEditorTemplate}" />
-                                            </DataTrigger>
-                                            <DataTrigger Property="Type" Value="Number">
-                                                <PropertySetter Property="ContentTemplate"
+                                            </behaviours:DataTrigger>
+                                            <behaviours:DataTrigger Property="Type" Value="Number">
+                                                <behaviours:PropertySetter Property="ContentTemplate"
                                                                 Value="{StaticResource ResourceKey=NumberEditorTemplate}" />
-                                            </DataTrigger>
-                                            <DataTrigger Property="Type" Value="Point">
-                                                <PropertySetter Property="ContentTemplate"
+                                            </behaviours:DataTrigger>
+                                            <behaviours:DataTrigger Property="Type" Value="Point">
+                                                <behaviours:PropertySetter Property="ContentTemplate"
                                                                 Value="{StaticResource ResourceKey=PointEditorTemplate}" />
-                                            </DataTrigger>
-                                            <DataTrigger Property="Type" Value="Option">
-                                                <PropertySetter Property="ContentTemplate"
+                                            </behaviours:DataTrigger>
+                                            <behaviours:DataTrigger Property="Type" Value="Option">
+                                                <behaviours:PropertySetter Property="ContentTemplate"
                                                                 Value="{StaticResource ResourceKey=OptionEditorTemplate}" />
-                                            </DataTrigger>
-                                            <DataTrigger Property="Type" Value="Text">
-                                                <PropertySetter Property="ContentTemplate"
+                                            </behaviours:DataTrigger>
+                                            <behaviours:DataTrigger Property="Type" Value="Text">
+                                                <behaviours:PropertySetter Property="ContentTemplate"
                                                                 Value="{StaticResource ResourceKey=TextEditorTemplate}" />
-                                            </DataTrigger>
+                                            </behaviours:DataTrigger>
                                         </BehaviorCollection>
                                     </BehaviorCollectionTemplate>
                                 </Setter>

--- a/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
+++ b/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -24,9 +24,9 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
+    <!--Condition below is needed to remove ProDiagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(ProDiagnosticsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
+++ b/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-browser</TargetFramework>
+    <TargetFramework>net10.0-browser</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
     <OutputType>Exe</OutputType>

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Shapes.Canvas"
              xmlns:nodify="https://miroiu.github.io/nodify"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
+             xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
              xmlns:controls="clr-namespace:Nodify.Shapes.Controls"
              xmlns:o="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              mc:Ignorable="d"
@@ -105,10 +106,10 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="CanvasToolbar.SelectedTool" Value="{x:Static local:CanvasTool.None}">
-                                    <PropertySetter Property="Cursor"
+                                <behaviours:DataTrigger Property="CanvasToolbar.SelectedTool" Value="{x:Static local:CanvasTool.None}">
+                                    <behaviours:PropertySetter Property="Cursor"
                                                     Value="{x:Static controls:Cursors.Arrow}" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -576,13 +577,13 @@
                     </ListBox.ItemsPanel>
                 </ListBox>
 
-                <WpfBtn Command="{Binding UndoCommand}"
+                <behaviours:WpfBtn Command="{Binding UndoCommand}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ContentTemplate="{StaticResource ArrowBackIcon}"
                         ToolTip.Tip="CTRL+Z"
                         Padding="1" />
 
-                <WpfBtn Command="{Binding RedoCommand}"
+                <behaviours:WpfBtn Command="{Binding RedoCommand}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ContentTemplate="{StaticResource ArrowForwardIcon}"
                         ToolTip.Tip="CTRL+SHIFT+z"
@@ -613,15 +614,15 @@
                     </ControlTheme>
                 </StackPanel.Resources>
 
-                <WpfBtn Command="{x:Static nodify:EditorCommands.ZoomIn}"
+                <behaviours:WpfBtn Command="{x:Static nodify:EditorCommands.ZoomIn}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ContentTemplate="{StaticResource PlusIcon}" />
 
-                <WpfBtn Command="{x:Static nodify:EditorCommands.ZoomOut}"
+                <behaviours:WpfBtn Command="{x:Static nodify:EditorCommands.ZoomOut}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ContentTemplate="{StaticResource MinusIcon}" />
 
-                <WpfBtn Command="{x:Static nodify:EditorCommands.FitToScreen}"
+                <behaviours:WpfBtn Command="{x:Static nodify:EditorCommands.FitToScreen}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ContentTemplate="{StaticResource MaximizeIcon}" />
 
@@ -635,10 +636,10 @@
                             <Setter Property="(Interaction.Behaviors)">
                                 <BehaviorCollectionTemplate>
                                     <BehaviorCollection>
-                                        <DataTrigger Property="Locked" Value="True">
-                                            <PropertySetter Property="ContentTemplate"
+                                        <behaviours:DataTrigger Property="Locked" Value="True">
+                                            <behaviours:PropertySetter Property="ContentTemplate"
                                                             Value="{StaticResource LockIcon}" />
-                                        </DataTrigger>
+                                        </behaviours:DataTrigger>
                                     </BehaviorCollection>
                                 </BehaviorCollectionTemplate>
                             </Setter>
@@ -672,7 +673,7 @@
                             <Border.Effect>
                                 <DropShadowDirectionEffect ShadowDepth="1" />
                             </Border.Effect>
-                            <WpfBtn Command="{x:Static nodify:EditorCommands.BringIntoView}"
+                            <behaviours:WpfBtn Command="{x:Static nodify:EditorCommands.BringIntoView}"
                                     CommandParameter="{Binding Location}"
                                     CommandTarget="{Binding ElementName=Editor}"
                                     Theme="{StaticResource IconButton}"

--- a/Examples/Nodify.Shapes/Nodify.Shapes.csproj
+++ b/Examples/Nodify.Shapes/Nodify.Shapes.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -18,9 +18,9 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
+    <!--Condition below is needed to remove ProDiagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(ProDiagnosticsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shared/Behaviours/DataTrigger.cs
+++ b/Examples/Nodify.Shared/Behaviours/DataTrigger.cs
@@ -8,7 +8,6 @@ using Avalonia.Metadata;
 using Avalonia.Reactive;
 using Avalonia.Xaml.Interactivity;
 
-[assembly: XmlnsDefinition("https://github.com/avaloniaui", "Nodify.Shared.Behaviours")]
 
 namespace Nodify.Shared.Behaviours;
 

--- a/Examples/Nodify.Shared/Nodify.Shared.csproj
+++ b/Examples/Nodify.Shared/Nodify.Shared.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shared/Themes/Generic.xaml
+++ b/Examples/Nodify.Shared/Themes/Generic.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:Nodify">
+                    xmlns:local="clr-namespace:Nodify"
+                    xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Nodify.Shared/Themes/Controls.xaml" />
@@ -268,10 +269,10 @@
                                                 <Setter Property="(Interaction.Behaviors)">
                                                     <BehaviorCollectionTemplate>
                                                         <BehaviorCollection>
-                                                            <DataTrigger Property="." Value="{Binding Path=SelectedColor, RelativeSource={RelativeSource AncestorType=local:Swatches}}">
-                                                                <PropertySetter Property="Background"
+                                                            <behaviours:DataTrigger Property="." Value="{Binding Path=SelectedColor, RelativeSource={RelativeSource AncestorType=local:Swatches}}">
+                                                                <behaviours:PropertySetter Property="Background"
                                                                     Value="White" />
-                                                            </DataTrigger>
+                                                            </behaviours:DataTrigger>
                                                         </BehaviorCollection>
                                                     </BehaviorCollectionTemplate>
                                                 </Setter>

--- a/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
+++ b/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Nodify.StateMachine"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
+             xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance Type={x:Type local:BlackboardKeyEditorViewModel}, IsDesignTimeCreatable=True}"
              d:Background="{DynamicResource PanelBackgroundBrush}"
@@ -90,32 +91,32 @@
                         <Setter Property="(Interaction.Behaviors)">
                             <BehaviorCollectionTemplate>
                                 <BehaviorCollection>
-                                    <DataTrigger Property="Target.Type" Value="Boolean">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource BooleanTemplate}" />
-                                    </DataTrigger>
-                                    <DataTrigger Property="Target.Type" Value="Integer">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource IntegerTemplate}" />
-                                    </DataTrigger>
+                                    <behaviours:DataTrigger Property="Target.Type" Value="Boolean">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource BooleanTemplate}" />
+                                    </behaviours:DataTrigger>
+                                    <behaviours:DataTrigger Property="Target.Type" Value="Integer">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource IntegerTemplate}" />
+                                    </behaviours:DataTrigger>
 
-                                    <DataTrigger Property="Target.Type" Value="Double">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource DoubleTemplate}" />
-                                    </DataTrigger>
+                                    <behaviours:DataTrigger Property="Target.Type" Value="Double">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource DoubleTemplate}" />
+                                    </behaviours:DataTrigger>
 
-                                    <DataTrigger Property="Target.Type" Value="String">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource StringTemplate}" />
-                                    </DataTrigger>
+                                    <behaviours:DataTrigger Property="Target.Type" Value="String">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource StringTemplate}" />
+                                    </behaviours:DataTrigger>
 
-                                    <DataTrigger Property="Target.Type" Value="Object">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource ObjectTemplate}" />
-                                    </DataTrigger>
+                                    <behaviours:DataTrigger Property="Target.Type" Value="Object">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource ObjectTemplate}" />
+                                    </behaviours:DataTrigger>
 
                                     <!-- there is no Key type, some leftover in Nodify? -->
-                                    <!-- <DataTrigger Binding="Target.Type" Value="Key"> -->
-                                    <!--     <PropertySetter Property="ContentTemplate" Value="{StaticResource KeyTemplate}" /> -->
-                                    <!-- </DataTrigger> -->
-                                    <DataTrigger Property="Target.ValueIsKey" Value="True">
-                                        <PropertySetter Property="ContentTemplate" Value="{StaticResource KeyTemplate}" />
-                                    </DataTrigger>
+                                    <!-- <behaviours:DataTrigger Binding="Target.Type" Value="Key"> -->
+                                    <!--     <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource KeyTemplate}" /> -->
+                                    <!-- </behaviours:DataTrigger> -->
+                                    <behaviours:DataTrigger Property="Target.ValueIsKey" Value="True">
+                                        <behaviours:PropertySetter Property="ContentTemplate" Value="{StaticResource KeyTemplate}" />
+                                    </behaviours:DataTrigger>
                                 </BehaviorCollection>
                             </BehaviorCollectionTemplate>
                         </Setter>
@@ -135,12 +136,12 @@
                         <Setter Property="(Interaction.Behaviors)">
                             <BehaviorCollectionTemplate>
                                 <BehaviorCollection>
-                                    <DataTrigger Property="IsChecked"
+                                    <behaviours:DataTrigger Property="IsChecked"
                                                  UseDataContext="False"
                                                  Value="True">
-                                        <PropertySetter Property="Content"
+                                        <behaviours:PropertySetter Property="Content"
                                                         Value="{StaticResource DiamondFillIcon}" />
-                                    </DataTrigger>
+                                    </behaviours:DataTrigger>
                                 </BehaviorCollection>
                             </BehaviorCollectionTemplate>
                         </Setter>

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -98,13 +98,13 @@
                                     <Setter Property="(Interaction.Behaviors)">
                                         <BehaviorCollectionTemplate>
                                             <BehaviorCollection>
-                                                <DataTrigger Property="IsActive"
+                                                <behaviours:DataTrigger Property="IsActive"
                                                                         Value="True">
-                                                    <PropertySetter Property="Stroke"
+                                                    <behaviours:PropertySetter Property="Stroke"
                                                                     Value="{DynamicResource ActiveStateBrush}" />
-                                                    <PropertySetter Property="StrokeThickness"
+                                                    <behaviours:PropertySetter Property="StrokeThickness"
                                                                     Value="6" />
-                                                </DataTrigger>
+                                                </behaviours:DataTrigger>
                                             </BehaviorCollection>
                                         </BehaviorCollectionTemplate>
                                     </Setter>
@@ -142,16 +142,16 @@
                                     <Setter Property="(Interaction.Behaviors)">
                                         <BehaviorCollectionTemplate>
                                             <BehaviorCollection>
-                                                <DataTrigger Property="IsEditable"
+                                                <behaviours:DataTrigger Property="IsEditable"
                                                              Value="False">
-                                                    <PropertySetter Property="BorderBrush"
+                                                    <behaviours:PropertySetter Property="BorderBrush"
                                                                     Value="{DynamicResource ReadOnlyStateBrush}" />
-                                                </DataTrigger>
-                                                <DataTrigger Property="IsActive"
+                                                </behaviours:DataTrigger>
+                                                <behaviours:DataTrigger Property="IsActive"
                                                              Value="True">
-                                                    <PropertySetter Property="BorderBrush"
+                                                    <behaviours:PropertySetter Property="BorderBrush"
                                                                     Value="{DynamicResource ActiveStateBrush}" />
-                                                </DataTrigger>
+                                                </behaviours:DataTrigger>
                                             </BehaviorCollection>
                                         </BehaviorCollectionTemplate>
                                     </Setter>
@@ -264,18 +264,18 @@
                             <Setter Property="(Interaction.Behaviors)">
                                 <BehaviorCollectionTemplate>
                                     <BehaviorCollection>
-                                        <DataTrigger Property="Runner.State"
+                                        <behaviours:DataTrigger Property="Runner.State"
                                                      Value="Stopped">
-                                            <PropertySetter Property="IsVisible"
+                                            <behaviours:PropertySetter Property="IsVisible"
                                                             Value="False" />
-                                        </DataTrigger>
-                                        <DataTrigger Property="Runner.State"
+                                        </behaviours:DataTrigger>
+                                        <behaviours:DataTrigger Property="Runner.State"
                                                      Value="Paused">
-                                            <PropertySetter Property="Content"
+                                            <behaviours:PropertySetter Property="Content"
                                                             Value="{StaticResource UnpauseIcon}" />
-                                            <PropertySetter Property="(ToolTip.Tip)"
+                                            <behaviours:PropertySetter Property="(ToolTip.Tip)"
                                                             Value="Continue" />
-                                        </DataTrigger>
+                                        </behaviours:DataTrigger>
                                     </BehaviorCollection>
                                 </BehaviorCollectionTemplate>
                             </Setter>
@@ -296,13 +296,13 @@
                                     <Setter Property="(Interaction.Behaviors)">
                                         <BehaviorCollectionTemplate>
                                             <BehaviorCollection>
-                                                <DataTrigger Property="Runner.State"
+                                                <behaviours:DataTrigger Property="Runner.State"
                                                              Value="Stopped">
-                                                    <PropertySetter Property="Content"
+                                                    <behaviours:PropertySetter Property="Content"
                                                                     Value="{StaticResource RunIcon}" />
-                                                    <PropertySetter Property="(ToolTip.Tip)"
+                                                    <behaviours:PropertySetter Property="(ToolTip.Tip)"
                                                                     Value="Run" />
-                                                </DataTrigger>
+                                                </behaviours:DataTrigger>
                                             </BehaviorCollection>
                                         </BehaviorCollectionTemplate>
                                     </Setter>
@@ -315,13 +315,13 @@
 
                 <Separator Width="1" Height="20" />
 
-                <WpfBtn Content="{StaticResource ZoomInIcon}"
+                <behaviours:WpfBtn Content="{StaticResource ZoomInIcon}"
                         Command="{x:Static nodify:EditorCommands.ZoomIn}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ToolTip.Tip="Zoom In"
                         Theme="{StaticResource IconButton}" />
 
-                <WpfBtn Content="{StaticResource ZoomOutIcon}"
+                <behaviours:WpfBtn Content="{StaticResource ZoomOutIcon}"
                         Command="{x:Static nodify:EditorCommands.ZoomOut}"
                         CommandTarget="{Binding ElementName=Editor}"
                         ToolTip.Tip="Zoom Out"
@@ -350,12 +350,12 @@
                     <Setter Property="(Interaction.Behaviors)">
                         <BehaviorCollectionTemplate>
                             <BehaviorCollection>
-                                <DataTrigger Property="IsExpanded"
+                                <behaviours:DataTrigger Property="IsExpanded"
                                              UseDataContext="False"
                                              Value="True">
-                                    <PropertySetter Property="Tag"
+                                    <behaviours:PropertySetter Property="Tag"
                                                     Value="{StaticResource ExpandLeftIcon}" />
-                                </DataTrigger>
+                                </behaviours:DataTrigger>
                             </BehaviorCollection>
                         </BehaviorCollectionTemplate>
                     </Setter>
@@ -409,12 +409,12 @@
                                                     <Setter Property="(Interaction.Behaviors)">
                                                         <BehaviorCollectionTemplate>
                                                             <BehaviorCollection>
-                                                                <DataTrigger Property="IsExpanded"
+                                                                <behaviours:DataTrigger Property="IsExpanded"
                                                                              UseDataContext="False"
                                                                              Value="True">
-                                                                    <PropertySetter Property="Tag"
+                                                                    <behaviours:PropertySetter Property="Tag"
                                                                         Value="{StaticResource ExpandDownIcon}" />
-                                                                </DataTrigger>
+                                                                </behaviours:DataTrigger>
                                                             </BehaviorCollection>
                                                         </BehaviorCollectionTemplate>
                                                     </Setter>
@@ -429,11 +429,11 @@
                                                             <Setter Property="(Interaction.Behaviors)">
                                                                 <BehaviorCollectionTemplate>
                                                                     <BehaviorCollection>
-                                                                        <DataTrigger Property="IsActive"
+                                                                        <behaviours:DataTrigger Property="IsActive"
                                                                                      Value="True">
-                                                                            <PropertySetter Property="Foreground"
+                                                                            <behaviours:PropertySetter Property="Foreground"
                                                                                             Value="{DynamicResource ActiveStateBrush}" />
-                                                                        </DataTrigger>
+                                                                        </behaviours:DataTrigger>
                                                                     </BehaviorCollection>
                                                                 </BehaviorCollectionTemplate>
                                                             </Setter>
@@ -499,28 +499,28 @@
                                                         <StackPanel Orientation="Horizontal">
                                                             <TextBlock Text="From: "
                                                                        VerticalAlignment="Center" />
-                                                            <WpfBtn Theme="{StaticResource IconButton}"
+                                                            <behaviours:WpfBtn Theme="{StaticResource IconButton}"
                                                                     Command="{x:Static nodify:EditorCommands.BringIntoView}"
                                                                     CommandParameter="{Binding Source.Location}"
                                                                     CommandTarget="{Binding ElementName=Editor}"
                                                                     Foreground="DodgerBlue">
                                                                 <TextBlock Text="{Binding Source.Name}"
                                                                            TextDecorations="Underline" />
-                                                            </WpfBtn>
+                                                            </behaviours:WpfBtn>
                                                         </StackPanel>
 
                                                         <StackPanel Orientation="Horizontal"
                                                                     Grid.Column="1">
                                                             <TextBlock Text="To: "
                                                                        VerticalAlignment="Center" />
-                                                            <WpfBtn Theme="{StaticResource IconButton}"
+                                                            <behaviours:WpfBtn Theme="{StaticResource IconButton}"
                                                                     Command="{x:Static nodify:EditorCommands.BringIntoView}"
                                                                     CommandParameter="{Binding Target.Location}"
                                                                     CommandTarget="{Binding ElementName=Editor}"
                                                                     Foreground="DodgerBlue">
                                                                 <TextBlock Text="{Binding Target.Name}"
                                                                            TextDecorations="Underline" />
-                                                            </WpfBtn>
+                                                            </behaviours:WpfBtn>
                                                         </StackPanel>
                                                     </Grid>
                                                 </Grid>
@@ -610,9 +610,9 @@
                                             <Setter Property="(Interaction.Behaviors)">
                                                 <BehaviorCollectionTemplate>
                                                     <BehaviorCollection>
-                                                        <DataTrigger Property="IsExpanded" UseDataContext="False" Value="True">
-                                                            <PropertySetter Property="Tag" Value="{StaticResource ExpandDownIcon}" />
-                                                        </DataTrigger>
+                                                        <behaviours:DataTrigger Property="IsExpanded" UseDataContext="False" Value="True">
+                                                            <behaviours:PropertySetter Property="Tag" Value="{StaticResource ExpandDownIcon}" />
+                                                        </behaviours:DataTrigger>
                                                     </BehaviorCollection>
                                                 </BehaviorCollectionTemplate>
                                             </Setter>
@@ -655,9 +655,9 @@
                                             <Setter Property="(Interaction.Behaviors)">
                                                 <BehaviorCollectionTemplate>
                                                     <BehaviorCollection>
-                                                        <DataTrigger Property="IsExpanded" UseDataContext="False" Value="True">
-                                                            <PropertySetter Property="Tag" Value="{StaticResource ExpandDownIcon}" />
-                                                        </DataTrigger>
+                                                        <behaviours:DataTrigger Property="IsExpanded" UseDataContext="False" Value="True">
+                                                            <behaviours:PropertySetter Property="Tag" Value="{StaticResource ExpandDownIcon}" />
+                                                        </behaviours:DataTrigger>
                                                     </BehaviorCollection>
                                                 </BehaviorCollectionTemplate>
                                             </Setter>

--- a/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
+++ b/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net9</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <AssemblyOriginatorKeyFile>..\..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -17,9 +18,9 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="$(XamlBehaviorsVersion)"/>
+    <!--Condition below is needed to remove ProDiagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(ProDiagnosticsVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Nodify/Compatibility/Commands/CommandManager.cs
+++ b/Nodify/Compatibility/Commands/CommandManager.cs
@@ -50,7 +50,7 @@ internal static class CommandManager
         InvalidateRequerySuggested();
     }
 
-    private static void GotFocusEventHandler(Interactive sender, GotFocusEventArgs e)
+    private static void GotFocusEventHandler(Interactive sender, Avalonia.Input.FocusChangedEventArgs e)
     {
         InvalidateRequerySuggested();
     }

--- a/Nodify/Compatibility/Commands/RoutedCommand.cs
+++ b/Nodify/Compatibility/Commands/RoutedCommand.cs
@@ -44,7 +44,7 @@ public class RoutedCommand : ICommand
         CommandManager.InvalidateRequerySuggested();
     }
 
-    private static void GotFocusEventHandler(Interactive focused, GotFocusEventArgs e)
+    private static void GotFocusEventHandler(Interactive focused, Avalonia.Input.FocusChangedEventArgs e)
     {
         _focusedElement = focused as IInputElement;
     }
@@ -80,7 +80,7 @@ public class RoutedCommand : ICommand
             }
 
             if (control is PopupRoot popup)
-                control = ((IHostedVisualTreeRoot)popup).Host as Interactive;
+                control = popup.Parent as Interactive;
             else
                 control = control.Parent as Interactive;
         }
@@ -111,7 +111,7 @@ public class RoutedCommand : ICommand
             }
 
             if (control is PopupRoot popup)
-                control = ((IHostedVisualTreeRoot)popup).Host as Interactive;
+                control = popup.Parent as Interactive;
             else
                 control = control.Parent as Interactive;
         }

--- a/Nodify/Helpers/SelectionHelper.cs
+++ b/Nodify/Helpers/SelectionHelper.cs
@@ -131,7 +131,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 container.IsPreviewingSelection = false;
             }
         }
@@ -148,7 +148,7 @@ namespace Nodify
                 ItemCollection items = _host.Items;
                 for (var i = 0; i < items.Count; i++)
                 {
-                    var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                    var container = (ItemContainer)_host.ContainerFromIndex(i);
                     if (container.IsSelectableInArea(area, fit))
                     {
                         container.IsPreviewingSelection = true;
@@ -162,7 +162,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     container.IsPreviewingSelection = false;
@@ -183,7 +183,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     container.IsPreviewingSelection = !container.IsPreviewingSelection;

--- a/Nodify/Minimap/Minimap.cs
+++ b/Nodify/Minimap/Minimap.cs
@@ -26,7 +26,7 @@ namespace Nodify
         public static readonly StyledProperty<bool> ResizeToViewportProperty = AvaloniaProperty.Register<Minimap, bool>(nameof(ResizeToViewport));
         public static readonly StyledProperty<bool> IsReadOnlyProperty = TextBox.IsReadOnlyProperty.AddOwner<Minimap>();
 
-        public static readonly RoutedEvent ZoomEvent = RoutedEvent.Register<ZoomEventArgs>(nameof(Zoom), RoutingStrategies.Bubble, typeof(Minimap));
+        public static readonly RoutedEvent<ZoomEventArgs> ZoomEvent = RoutedEvent.Register<ZoomEventArgs>(nameof(Zoom), RoutingStrategies.Bubble, typeof(Minimap));
 
         /// <inheritdoc cref="NodifyEditor.ViewportLocation" />
         public Point ViewportLocation

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>miroiu, bandysc</Authors>

--- a/Nodify/NodifyEditor.Scrolling.cs
+++ b/Nodify/NodifyEditor.Scrolling.cs
@@ -14,8 +14,8 @@ namespace Nodify
         /// </summary>
         public static double ScrollIncrement { get; set; } = MouseWheelDeltaForOneLine / 2;
 
-        bool ILogicalScrollable.CanHorizontallyScroll { get; set; }
-        bool ILogicalScrollable.CanVerticallyScroll { get; set; }
+        public bool CanHorizontallyScroll { get; set; }
+        public bool CanVerticallyScroll { get; set; }
 
         private double _extentWidth;
         double IScrollInfo.ExtentWidth => _extentWidth;

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -80,7 +80,7 @@ namespace Nodify
             editor.TranslateTransform.X = -translate.X * editor.ViewportZoom;
             editor.TranslateTransform.Y = -translate.Y * editor.ViewportZoom;
 
-            var renderScale = (editor.GetVisualRoot()?.RenderScaling ?? 1);
+            var renderScale = Avalonia.Controls.TopLevel.GetTopLevel(editor)?.RenderScaling ?? 1;
             editor.DpiScaledTranslateTransform.X = editor.TranslateTransform.X * renderScale;
             editor.DpiScaledTranslateTransform.Y = editor.TranslateTransform.Y * renderScale;
 
@@ -932,7 +932,7 @@ namespace Nodify
 
                 for (var i = 0; i < items.Count; i++)
                 {
-                    containers.Add((ItemContainer)ItemContainerGenerator.ContainerFromIndex(i));
+                    containers.Add((ItemContainer)ContainerFromIndex(i));
                 }
 
                 return containers;
@@ -969,7 +969,7 @@ namespace Nodify
         /// </summary>
         public NodifyEditor()
         {
-            AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, OnPointerTouchPadGestureMagnify);
+            AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, OnPointerTouchPadGestureMagnify);
             AddHandler(Connector.DisconnectEvent, new ConnectorEventHandler(OnConnectorDisconnected));
             AddHandler(Connector.PendingConnectionStartedEvent, new PendingConnectionEventHandler(OnConnectionStarted));
             AddHandler(Connector.PendingConnectionCompletedEvent, new PendingConnectionEventHandler(OnConnectionCompleted));
@@ -1487,7 +1487,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 if (container.IsPreviewingSelection == true && container.IsSelectable)
                 {
                     Selection.Select(i);
@@ -1507,7 +1507,7 @@ namespace Nodify
             ItemCollection items = Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 container.IsPreviewingSelection = null;
             }
         }
@@ -1525,7 +1525,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
 
                 if (container.IsSelectableInArea(area, fit))
                 {
@@ -1563,7 +1563,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     Selection.Select(i);

--- a/Nodify/Themes/Styles/Minimap.xaml
+++ b/Nodify/Themes/Styles/Minimap.xaml
@@ -45,11 +45,11 @@
                                 <ItemsPresenter Name="PART_ItemsPresenter">
                                     <ItemsPresenter.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <local:MinimapPanel ViewportSize="{TemplateBinding ViewportSize}"
-                                                                ViewportLocation="{TemplateBinding ViewportLocation}"
-                                                                ResizeToViewport="{TemplateBinding ResizeToViewport}"
-                                                                Extent="{Binding Extent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWayToSource}"
-                                                                ItemsExtent="{Binding ItemsExtent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWayToSource}" />
+                                            <local:MinimapPanel ViewportSize="{Binding ViewportSize, RelativeSource={RelativeSource AncestorType=local:Minimap}}"
+                                                                ViewportLocation="{Binding ViewportLocation, RelativeSource={RelativeSource AncestorType=local:Minimap}}"
+                                                                ResizeToViewport="{Binding ResizeToViewport, RelativeSource={RelativeSource AncestorType=local:Minimap}}"
+                                                                Extent="{Binding Extent, RelativeSource={RelativeSource AncestorType=local:Minimap}, Mode=OneWayToSource}"
+                                                                ItemsExtent="{Binding ItemsExtent, RelativeSource={RelativeSource AncestorType=local:Minimap}, Mode=OneWayToSource}" />
                                         </ItemsPanelTemplate>
                                     </ItemsPresenter.ItemsPanel>
                                 </ItemsPresenter>

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -73,7 +73,7 @@
                             <ItemsPresenter Name="PART_ItemsPresenter">
                                 <ItemsPresenter.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <local:NodifyCanvas Extent="{Binding ItemsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <local:NodifyCanvas Extent="{Binding ItemsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource AncestorType=local:NodifyEditor}}" />
                                     </ItemsPanelTemplate>
                                 </ItemsPresenter.ItemsPanel>
                             </ItemsPresenter>

--- a/build_cloudflare.sh
+++ b/build_cloudflare.sh
@@ -2,7 +2,7 @@
 #apt-get install python3 brotli -y
 curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
 chmod +x dotnet-install.sh
-./dotnet-install.sh -c 9.0 -InstallDir ./dotnet
+./dotnet-install.sh -c 10.0 -InstallDir ./dotnet
 ./dotnet/dotnet --version
 ./dotnet/dotnet workload restore
 ./dotnet/dotnet restore


### PR DESCRIPTION
fix: #43 

Lib was straight forward, but the samples required heavier refactoring to fix deprecations and changes to accommodate the new version.

Lib:
  - `Nodify/Minimap/Minimap.cs` - ZoomEvent typed as `RoutedEvent<ZoomEventArgs>` so XAML can hook Zoom="Handler" under Avalonia 12's compiler.

Samples:
  - All example projects switched from net9 -> net10.0; `Nodify.Shapes.Web` -> net10.0-browser.
  - Replaced deprecated `Avalonia.Xaml.Behaviors` 11.1.0.4 -> `Xaml.Behaviors.Avalonia` 12.0.0.
  - Replaced `Avalonia.Diagnostics` -> `ProDiagnostics` 12.0.0 (Debug-only, hail wieslawsoltes).
  - Removed the `[XmlnsDefinition]` for `Nodify.Shared.Behaviours` since `DataTrigger/PropertySetter/WpfBtn` were colliding with the new Xaml.Behaviors types; prefixed usages with behaviours: across all sample XAMLs.
  - Added `AvaloniaUseCompiledBindingsByDefault=false` to Calculator / Playground / StateMachine / Shared (Avalonia 12 defaults to compiled bindings; these samples use untyped DataContext).
  - Calculator: rewrote drag-drop for Avalonia 12's new `IDataTransfer` / `DragDrop.DoDragDropAsync` API.
  - Playground WpfComboBox: replaced removed `GetVisualRoot()` extension with `GetSelfAndVisualAncestors().LastOrDefault()`.

  Build infra:
  - `Directory.Build.props` - added `XamlBehaviorsVersion` / `ProDiagnosticsVersion`.
  - `build_cloudflare.sh` - installs .NET 10 instead of 9.
  
Testing:
Local testing of sample projects. Author will want to do a more thurough sweep, but wanted to get this out there in case others want to grab the changes now.