### PR TITLE
Add Avalonia 12 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AvaloniaVersion>12.0.1</AvaloniaVersion>
+    <AvaloniaVersion>12.0.3</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AvaloniaVersion>11.1.0</AvaloniaVersion>
+    <AvaloniaVersion>12.0.1</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -11,7 +11,7 @@
              xmlns:compatibility="clr-namespace:Nodify.Compatibility;assembly=Nodify"
              d:DataContext="{d:DesignInstance Type=local:EditorViewModel}"
              mc:Ignorable="d"
-             x:CompileBindings="False"
+             x:DataType="local:EditorViewModel"
              d:DesignHeight="450"
              d:DesignWidth="800">
     <UserControl.Resources>
@@ -129,6 +129,7 @@
         </DataTemplate>
         
         <ControlTheme x:Key="ItemContainerStyle"
+               x:DataType="local:OperationViewModel"
                TargetType="{x:Type nodify:ItemContainer}"
                BasedOn="{StaticResource {x:Type nodify:ItemContainer}}">
             <Setter Property="Location"

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -11,6 +11,7 @@
              xmlns:compatibility="clr-namespace:Nodify.Compatibility;assembly=Nodify"
              d:DataContext="{d:DesignInstance Type=local:EditorViewModel}"
              mc:Ignorable="d"
+             x:CompileBindings="False"
              d:DesignHeight="450"
              d:DesignWidth="800">
     <UserControl.Resources>

--- a/Examples/Nodify.Calculator/EditorView.xaml.cs
+++ b/Examples/Nodify.Calculator/EditorView.xaml.cs
@@ -6,6 +6,9 @@ namespace Nodify.Calculator
 {
     public partial class EditorView : UserControl
     {
+        private static readonly DataFormat<OperationInfoViewModel> _operationFormat =
+            DataFormat.CreateInProcessFormat<OperationInfoViewModel>(typeof(OperationInfoViewModel).FullName!);
+
         public EditorView()
         {
             InitializeComponent();
@@ -46,8 +49,16 @@ namespace Nodify.Calculator
         private void OnDropNode(object? sender, DragEventArgs e)
         {
             NodifyEditor? editor = (e.Source as NodifyEditor) ?? (e.Source as Control)?.GetLogicalParent() as NodifyEditor;
-            if(editor != null && editor.DataContext is CalculatorViewModel calculator
-                && e.Data.Get(typeof(OperationInfoViewModel).FullName) is OperationInfoViewModel operation)
+            OperationInfoViewModel? operation = null;
+            foreach (var item in e.DataTransfer.Items)
+            {
+                if (item.TryGetRaw(_operationFormat) is OperationInfoViewModel op)
+                {
+                    operation = op;
+                    break;
+                }
+            }
+            if (editor != null && editor.DataContext is CalculatorViewModel calculator && operation != null)
             {
                 OperationViewModel op = OperationFactory.GetOperation(operation);
                 op.Location = editor.GetLocationInsideEditor(e);
@@ -57,13 +68,16 @@ namespace Nodify.Calculator
             }
         }
         
-        private void OnNodeDrag(object? sender, MouseEventArgs e)
+        private async void OnNodeDrag(object? sender, MouseEventArgs e)
         {
-            if(leftButtonPressed && ((Control)sender).DataContext is OperationInfoViewModel operation)
+            if (leftButtonPressed && _lastPointerPressed != null && ((Control)sender).DataContext is OperationInfoViewModel operation)
             {
-                var data = new DataObject();
-                data.Set(typeof(OperationInfoViewModel).FullName, operation);
-                DragDrop.DoDragDrop(e, data, DragDropEffects.Copy);
+                leftButtonPressed = false;
+                var item = new DataTransferItem();
+                item.Set(_operationFormat, operation);
+                var data = new DataTransfer();
+                data.Add(item);
+                await DragDrop.DoDragDropAsync(_lastPointerPressed, data, DragDropEffects.Copy);
             }
         }
 
@@ -71,6 +85,8 @@ namespace Nodify.Calculator
         {
             leftButtonPressed = e.GetCurrentPoint(this).Properties.PointerUpdateKind ==
                                 PointerUpdateKind.LeftButtonPressed;
+            if (leftButtonPressed)
+                _lastPointerPressed = e;
         }
 
         private void OnNodeExited(object? sender, PointerEventArgs e)
@@ -79,5 +95,6 @@ namespace Nodify.Calculator
         }
         
         private bool leftButtonPressed;
+        private PointerPressedEventArgs? _lastPointerPressed;
     }
 }

--- a/Examples/Nodify.Calculator/MainWindow.xaml
+++ b/Examples/Nodify.Calculator/MainWindow.xaml
@@ -8,7 +8,7 @@
         Background="{DynamicResource NodifyEditor.BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}"
         mc:Ignorable="d"
-        x:CompileBindings="False"
+        x:DataType="local:ApplicationViewModel"
         Title="MainWindow"
         Height="650"
         Width="1200">
@@ -43,7 +43,8 @@
                              AddTabCommand="{Binding AddEditorCommand}"
                              AutoScrollToEnd="{Binding AutoSelectNewEditor}">
             <shared:TabControlEx.ItemContainerTheme>
-                <ControlTheme TargetType="{x:Type shared:TabItemEx}" 
+                <ControlTheme TargetType="{x:Type shared:TabItemEx}"
+                       x:DataType="local:EditorViewModel"
                        BasedOn="{StaticResource {x:Type shared:TabItemEx}}">
                     <Setter Property="Header" 
                             Value="{Binding Name}"/>

--- a/Examples/Nodify.Calculator/MainWindow.xaml
+++ b/Examples/Nodify.Calculator/MainWindow.xaml
@@ -8,6 +8,7 @@
         Background="{DynamicResource NodifyEditor.BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}"
         mc:Ignorable="d"
+        x:CompileBindings="False"
         Title="MainWindow"
         Height="650"
         Width="1200">

--- a/Examples/Nodify.Calculator/Nodify.Calculator.csproj
+++ b/Examples/Nodify.Calculator/Nodify.Calculator.csproj
@@ -21,9 +21,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Calculator/OperationsMenuView.xaml
+++ b/Examples/Nodify.Calculator/OperationsMenuView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Calculator"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
+             x:CompileBindings="False"
              MinWidth="250"
              d:DesignHeight="400"
              d:DesignWidth="250"

--- a/Examples/Nodify.Calculator/OperationsMenuView.xaml
+++ b/Examples/Nodify.Calculator/OperationsMenuView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Calculator"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
-             x:CompileBindings="False"
+             x:DataType="local:OperationsMenuViewModel"
              MinWidth="250"
              d:DesignHeight="400"
              d:DesignWidth="250"

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -7,7 +7,7 @@
              xmlns:nodify="https://miroiu.github.io/nodify"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
-             x:CompileBindings="False"
+             x:DataType="local:NodifyEditorViewModel"
              Background="{DynamicResource NodifyEditor.BackgroundBrush}"
              d:DesignHeight="450"
              d:DesignWidth="800">

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -7,6 +7,7 @@
              xmlns:nodify="https://miroiu.github.io/nodify"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
+             x:CompileBindings="False"
              Background="{DynamicResource NodifyEditor.BackgroundBrush}"
              d:DesignHeight="450"
              d:DesignWidth="800">

--- a/Examples/Nodify.Playground/Editor/WpfComboBox.cs
+++ b/Examples/Nodify.Playground/Editor/WpfComboBox.cs
@@ -28,7 +28,7 @@ public class WpfComboBox : ComboBox
     
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
-        if ((e.Source as Control)?.GetVisualRoot() is not PopupRoot)
+        if (TopLevel.GetTopLevel(e.Source as Control) is not PopupRoot)
             e.Handled = true;
         base.OnPointerReleased(e);
     }

--- a/Examples/Nodify.Playground/MainWindow.xaml
+++ b/Examples/Nodify.Playground/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
         xmlns:nodify="https://miroiu.github.io/nodify"
         mc:Ignorable="d"
-        x:CompileBindings="False"
+        x:DataType="local:PlaygroundViewModel"
         Title="MainWindow"
         Height="700"
         Width="1300">

--- a/Examples/Nodify.Playground/MainWindow.xaml
+++ b/Examples/Nodify.Playground/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
         xmlns:nodify="https://miroiu.github.io/nodify"
         mc:Ignorable="d"
+        x:CompileBindings="False"
         Title="MainWindow"
         Height="700"
         Width="1300">

--- a/Examples/Nodify.Playground/Nodify.Playground.csproj
+++ b/Examples/Nodify.Playground/Nodify.Playground.csproj
@@ -18,9 +18,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Playground/PointEditorView.xaml
+++ b/Examples/Nodify.Playground/PointEditorView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Playground"
              d:DataContext="{d:DesignInstance Type={x:Type local:PointEditor}, IsDesignTimeCreatable=True}"
              mc:Ignorable="d"
-             x:CompileBindings="False"
+             x:DataType="local:PointEditor"
              d:DesignHeight="450"
              d:DesignWidth="800">
     <Grid>

--- a/Examples/Nodify.Playground/PointEditorView.xaml
+++ b/Examples/Nodify.Playground/PointEditorView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Nodify.Playground"
              d:DataContext="{d:DesignInstance Type={x:Type local:PointEditor}, IsDesignTimeCreatable=True}"
              mc:Ignorable="d"
+             x:CompileBindings="False"
              d:DesignHeight="450"
              d:DesignWidth="800">
     <Grid>

--- a/Examples/Nodify.Playground/SettingsView.xaml
+++ b/Examples/Nodify.Playground/SettingsView.xaml
@@ -9,7 +9,7 @@
              d:Foreground="{DynamicResource ForegroundBrush}"
              d:Background="{DynamicResource PanelBackgroundBrush}"
              mc:Ignorable="d">
-    <ItemsControl ItemsSource="{Binding Items, RelativeSource={RelativeSource AncestorType=UserControl}}">
+    <ItemsControl ItemsSource="{Binding Items, RelativeSource={RelativeSource AncestorType=local:SettingsView}}">
         <ItemsControl.Resources>
             <DataTemplate x:Key="TextEditorTemplate" DataType="{x:Type local:ISettingViewModel}">
                 <TextBox Text="{Binding Value}" TextWrapping="Wrap" AcceptsReturn="True" />

--- a/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
+++ b/Examples/Nodify.Shapes.Desktop/Nodify.Shapes.Desktop.csproj
@@ -24,9 +24,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
+++ b/Examples/Nodify.Shapes.Web/Nodify.Shapes.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-browser</TargetFramework>
+    <TargetFramework>net10.0-browser</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
     <OutputType>Exe</OutputType>

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
@@ -100,7 +100,7 @@ namespace Nodify.Shapes.Canvas
 
         #endregion
 
-        private void Minimap_Zoom(object sender, ZoomEventArgs e)
+        private void Minimap_Zoom(object? sender, ZoomEventArgs e)
         {
             Editor.ZoomAtPosition(e.Zoom, e.Location);
         }

--- a/Examples/Nodify.Shapes/Nodify.Shapes.csproj
+++ b/Examples/Nodify.Shapes/Nodify.Shapes.csproj
@@ -18,9 +18,8 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shared/Nodify.Shared.csproj
+++ b/Examples/Nodify.Shared/Nodify.Shared.csproj
@@ -9,7 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Nodify.Shared/Themes/Generic.xaml
+++ b/Examples/Nodify.Shared/Themes/Generic.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:Nodify">
+                    xmlns:local="clr-namespace:Nodify"
+                    xmlns:behaviours="clr-namespace:Nodify.Shared.Behaviours;assembly=Nodify.Shared">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Nodify.Shared/Themes/Controls.xaml" />
@@ -268,10 +269,10 @@
                                                 <Setter Property="(Interaction.Behaviors)">
                                                     <BehaviorCollectionTemplate>
                                                         <BehaviorCollection>
-                                                            <DataTrigger Property="." Value="{Binding Path=SelectedColor, RelativeSource={RelativeSource AncestorType=local:Swatches}}">
-                                                                <PropertySetter Property="Background"
+                                                            <behaviours:DataTrigger Property="." Value="{Binding Path=SelectedColor, RelativeSource={RelativeSource AncestorType=local:Swatches}}">
+                                                                <behaviours:PropertySetter Property="Background"
                                                                     Value="White" />
-                                                            </DataTrigger>
+                                                            </behaviours:DataTrigger>
                                                         </BehaviorCollection>
                                                     </BehaviorCollectionTemplate>
                                                 </Setter>

--- a/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
+++ b/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Nodify.StateMachine"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
-             x:CompileBindings="False"
+             x:DataType="local:BlackboardKeyEditorViewModel"
              d:DataContext="{d:DesignInstance Type={x:Type local:BlackboardKeyEditorViewModel}, IsDesignTimeCreatable=True}"
              d:Background="{DynamicResource PanelBackgroundBrush}"
              d:DesignWidth="400">

--- a/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
+++ b/Examples/Nodify.StateMachine/BlackboardKeyEditorView.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Nodify.StateMachine"
              xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              mc:Ignorable="d"
+             x:CompileBindings="False"
              d:DataContext="{d:DesignInstance Type={x:Type local:BlackboardKeyEditorViewModel}, IsDesignTimeCreatable=True}"
              d:Background="{DynamicResource PanelBackgroundBrush}"
              d:DesignWidth="400">

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -11,7 +11,7 @@
         xmlns:compatibility="clr-namespace:Nodify.Compatibility;assembly=Nodify"
         CanResize="True"
         mc:Ignorable="d"
-        x:CompileBindings="False"
+        x:DataType="local:StateMachineViewModel"
         Background="{DynamicResource NodifyEditor.BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}"
         Title="State Machine Editor"

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -11,6 +11,7 @@
         xmlns:compatibility="clr-namespace:Nodify.Compatibility;assembly=Nodify"
         CanResize="True"
         mc:Ignorable="d"
+        x:CompileBindings="False"
         Background="{DynamicResource NodifyEditor.BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}"
         Title="State Machine Editor"

--- a/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
+++ b/Examples/Nodify.StateMachine/Nodify.StateMachine.csproj
@@ -17,9 +17,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4"/>
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0"/>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Nodify/Compatibility/Commands/CommandManager.cs
+++ b/Nodify/Compatibility/Commands/CommandManager.cs
@@ -50,7 +50,7 @@ internal static class CommandManager
         InvalidateRequerySuggested();
     }
 
-    private static void GotFocusEventHandler(Interactive sender, GotFocusEventArgs e)
+    private static void GotFocusEventHandler(Interactive sender, RoutedEventArgs e)
     {
         InvalidateRequerySuggested();
     }

--- a/Nodify/Compatibility/Commands/RoutedCommand.cs
+++ b/Nodify/Compatibility/Commands/RoutedCommand.cs
@@ -44,7 +44,7 @@ public class RoutedCommand : ICommand
         CommandManager.InvalidateRequerySuggested();
     }
 
-    private static void GotFocusEventHandler(Interactive focused, GotFocusEventArgs e)
+    private static void GotFocusEventHandler(Interactive focused, RoutedEventArgs e)
     {
         _focusedElement = focused as IInputElement;
     }
@@ -80,7 +80,7 @@ public class RoutedCommand : ICommand
             }
 
             if (control is PopupRoot popup)
-                control = ((IHostedVisualTreeRoot)popup).Host as Interactive;
+                control = popup.ParentTopLevel as Interactive;
             else
                 control = control.Parent as Interactive;
         }
@@ -110,8 +110,8 @@ public class RoutedCommand : ICommand
                 }
             }
 
-            if (control is PopupRoot popup)
-                control = ((IHostedVisualTreeRoot)popup).Host as Interactive;
+            if (control is PopupRoot popup2)
+                control = popup2.ParentTopLevel as Interactive;
             else
                 control = control.Parent as Interactive;
         }

--- a/Nodify/Helpers/SelectionHelper.cs
+++ b/Nodify/Helpers/SelectionHelper.cs
@@ -131,7 +131,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 container.IsPreviewingSelection = false;
             }
         }
@@ -148,7 +148,7 @@ namespace Nodify
                 ItemCollection items = _host.Items;
                 for (var i = 0; i < items.Count; i++)
                 {
-                    var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                    var container = (ItemContainer)_host.ContainerFromIndex(i);
                     if (container.IsSelectableInArea(area, fit))
                     {
                         container.IsPreviewingSelection = true;
@@ -162,7 +162,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     container.IsPreviewingSelection = false;
@@ -183,7 +183,7 @@ namespace Nodify
             ItemCollection items = _host.Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)_host.ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)_host.ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     container.IsPreviewingSelection = !container.IsPreviewingSelection;

--- a/Nodify/Minimap/Minimap.cs
+++ b/Nodify/Minimap/Minimap.cs
@@ -26,7 +26,7 @@ namespace Nodify
         public static readonly StyledProperty<bool> ResizeToViewportProperty = AvaloniaProperty.Register<Minimap, bool>(nameof(ResizeToViewport));
         public static readonly StyledProperty<bool> IsReadOnlyProperty = TextBox.IsReadOnlyProperty.AddOwner<Minimap>();
 
-        public static readonly RoutedEvent ZoomEvent = RoutedEvent.Register<ZoomEventArgs>(nameof(Zoom), RoutingStrategies.Bubble, typeof(Minimap));
+        public static readonly RoutedEvent<ZoomEventArgs> ZoomEvent = RoutedEvent.Register<ZoomEventArgs>(nameof(Zoom), RoutingStrategies.Bubble, typeof(Minimap));
 
         /// <inheritdoc cref="NodifyEditor.ViewportLocation" />
         public Point ViewportLocation
@@ -87,7 +87,7 @@ namespace Nodify
         }
 
         /// <summary>Triggered when zooming in or out using the mouse wheel.</summary>
-        public event ZoomEventHandler Zoom
+        public event EventHandler<ZoomEventArgs> Zoom
         {
             add => AddHandler(ZoomEvent, value);
             remove => RemoveHandler(ZoomEvent, value);

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>miroiu, bandysc</Authors>

--- a/Nodify/NodifyEditor.Scrolling.cs
+++ b/Nodify/NodifyEditor.Scrolling.cs
@@ -14,8 +14,8 @@ namespace Nodify
         /// </summary>
         public static double ScrollIncrement { get; set; } = MouseWheelDeltaForOneLine / 2;
 
-        bool ILogicalScrollable.CanHorizontallyScroll { get; set; }
-        bool ILogicalScrollable.CanVerticallyScroll { get; set; }
+        public bool CanHorizontallyScroll { get; set; }
+        public bool CanVerticallyScroll { get; set; }
 
         private double _extentWidth;
         double IScrollInfo.ExtentWidth => _extentWidth;

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -80,7 +80,7 @@ namespace Nodify
             editor.TranslateTransform.X = -translate.X * editor.ViewportZoom;
             editor.TranslateTransform.Y = -translate.Y * editor.ViewportZoom;
 
-            var renderScale = (editor.GetVisualRoot()?.RenderScaling ?? 1);
+            var renderScale = (TopLevel.GetTopLevel(editor)?.RenderScaling ?? 1);
             editor.DpiScaledTranslateTransform.X = editor.TranslateTransform.X * renderScale;
             editor.DpiScaledTranslateTransform.Y = editor.TranslateTransform.Y * renderScale;
 
@@ -932,7 +932,7 @@ namespace Nodify
 
                 for (var i = 0; i < items.Count; i++)
                 {
-                    containers.Add((ItemContainer)ItemContainerGenerator.ContainerFromIndex(i));
+                    containers.Add((ItemContainer)ContainerFromIndex(i));
                 }
 
                 return containers;
@@ -969,7 +969,7 @@ namespace Nodify
         /// </summary>
         public NodifyEditor()
         {
-            AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, OnPointerTouchPadGestureMagnify);
+            AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, OnPointerTouchPadGestureMagnify);
             AddHandler(Connector.DisconnectEvent, new ConnectorEventHandler(OnConnectorDisconnected));
             AddHandler(Connector.PendingConnectionStartedEvent, new PendingConnectionEventHandler(OnConnectionStarted));
             AddHandler(Connector.PendingConnectionCompletedEvent, new PendingConnectionEventHandler(OnConnectionCompleted));
@@ -1487,7 +1487,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 if (container.IsPreviewingSelection == true && container.IsSelectable)
                 {
                     Selection.Select(i);
@@ -1507,7 +1507,7 @@ namespace Nodify
             ItemCollection items = Items;
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 container.IsPreviewingSelection = null;
             }
         }
@@ -1525,7 +1525,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
 
                 if (container.IsSelectableInArea(area, fit))
                 {
@@ -1563,7 +1563,7 @@ namespace Nodify
             BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                var container = (ItemContainer)ContainerFromIndex(i);
                 if (container.IsSelectableInArea(area, fit))
                 {
                     Selection.Select(i);

--- a/Nodify/Themes/Styles/Connection.xaml
+++ b/Nodify/Themes/Styles/Connection.xaml
@@ -10,6 +10,9 @@
         <Style Selector="^[(local|BaseConnection.IsSelectable)=true]">
             <Setter Property="Cursor" Value="Hand" />
         </Style>
+        <Style Selector="^[(local|BaseConnection.IsSelected)=true]">
+            <Setter Property="OutlineBrush" Value="{DynamicResource ItemContainer.SelectedBrush}" />
+        </Style>
     </ControlTheme>
 
     <ControlTheme TargetType="{x:Type local:Connection}"

--- a/Nodify/Themes/Styles/Minimap.xaml
+++ b/Nodify/Themes/Styles/Minimap.xaml
@@ -45,11 +45,11 @@
                                 <ItemsPresenter Name="PART_ItemsPresenter">
                                     <ItemsPresenter.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <local:MinimapPanel ViewportSize="{TemplateBinding ViewportSize}"
-                                                                ViewportLocation="{TemplateBinding ViewportLocation}"
-                                                                ResizeToViewport="{TemplateBinding ResizeToViewport}"
-                                                                Extent="{Binding Extent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWayToSource}"
-                                                                ItemsExtent="{Binding ItemsExtent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWayToSource}" />
+                                                                <local:MinimapPanel ViewportSize="{Binding ViewportSize, RelativeSource={RelativeSource AncestorType={x:Type local:Minimap}}}"
+                                                                ViewportLocation="{Binding ViewportLocation, RelativeSource={RelativeSource AncestorType={x:Type local:Minimap}}}"
+                                                                ResizeToViewport="{Binding ResizeToViewport, RelativeSource={RelativeSource AncestorType={x:Type local:Minimap}}}"
+                                                                Extent="{Binding Extent, RelativeSource={RelativeSource AncestorType={x:Type local:Minimap}}, Mode=OneWayToSource}"
+                                                                ItemsExtent="{Binding ItemsExtent, RelativeSource={RelativeSource AncestorType={x:Type local:Minimap}}, Mode=OneWayToSource}" />
                                         </ItemsPanelTemplate>
                                     </ItemsPresenter.ItemsPanel>
                                 </ItemsPresenter>

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -73,7 +73,7 @@
                             <ItemsPresenter Name="PART_ItemsPresenter">
                                 <ItemsPresenter.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <local:NodifyCanvas Extent="{Binding ItemsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <local:NodifyCanvas Extent="{Binding ItemsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource AncestorType={x:Type local:NodifyEditor}}}" />
                                     </ItemsPanelTemplate>
                                 </ItemsPresenter.ItemsPanel>
                             </ItemsPresenter>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Avalonia version compatibility chart:
 
 | Nodify version | Avalonia version |
 |----------------|------------------|
+| unreleased     | 12.0.3           |
 | 6.6.0          | 11.1.0           |
 | 6.5.0          | 11.1.0           |
 | 6.2.0          | 11.1.0           |


### PR DESCRIPTION
## Summary
- Upgrade the Avalonia port from Avalonia 11.1.0 to Avalonia 12.0.3.
- Apply Avalonia 12 API and XAML compatibility changes for the core library and examples.
- Move the browser sample to `net10.0-browser`, which is required by `Avalonia.Browser` 12.x assets.
- Document the unreleased Avalonia 12 compatibility in the README chart.

The first three commits are cherry-picked from `JuenTingShie/nodify-avalonia` branch `copilot/update-avalonia-packages-to-12`, preserving commit authorship. The final commit updates the patch level to 12.0.3 and fixes the browser sample target framework so the full solution builds.

## Validation
- `dotnet build Nodify\Nodify.csproj -m:1 /nr:false /p:UseSharedCompilation=false -v:minimal` passed with existing warnings.
- `dotnet build Nodify.sln -m:1 /nr:false /p:UseSharedCompilation=false -v:minimal` passed. One WebAssembly workload warning remains about native references not being linked when neither `WasmBuildNative` nor `RunAOTCompilation` is enabled.

## Downstream Check
- This change set was verified downstream in `Kibnet/Unlimotion` against Avalonia 12.0.3 using an internal prerelease package built from the Avalonia 12 branch. The roadmap graph UI, AppAutomation Headless/FlaUI smoke suites, and Android build passed there.
## Compiled Bindings
- Removed the broad `x:CompileBindings="False"` overrides from Calculator, Playground, and StateMachine example views.
- Added explicit `x:DataType` annotations for the affected roots and item container themes so the examples keep compiled bindings where the data context is statically known.